### PR TITLE
Fix phpBB requirement to stipulate >= 3.1.0-RC2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"extra": {
 		"display-name": "Acme Demo Extension",
 		"soft-require": {
-			"phpbb/phpbb": "3.1.*@dev"
+			"phpbb/phpbb": ">=3.1.0-RC2,<3.2.*@dev"
 		}
 	}
 }


### PR DESCRIPTION
Due to the moving to soft-require the minimum requirement of this extension is RC2 and the old version requirement is incorrect (The old ones means it is compatible with any version of 3.1 from alpha onwards).
