### PR TITLE
Update routing.yml to use path instead of deprecated pattern

### DIFF
--- a/config/routing.yml
+++ b/config/routing.yml
@@ -1,3 +1,3 @@
 acme_demo_controller:
-    pattern: /demo/{name}
+    path: /demo/{name}
     defaults: { _controller: acme.demo.controller:handle }


### PR DESCRIPTION
According to Symfony, "path" should be used, not "pattern" in routing.yml.

"The path option was introduced in Symfony 2.2, pattern is used in older versions."
http://symfony.com/doc/2.3/book/routing.html

Currently both path and pattern are supported. But pattern will be fully deleted from Symfony in v3.
https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#routing

So in order to prevent that issue for all extensions, we should promote the use of "path" now instead, and since this extension serves as a demo for authors... ;)
